### PR TITLE
Archive file support - with wrap flag

### DIFF
--- a/bin/car-utils/src/archive.rs
+++ b/bin/car-utils/src/archive.rs
@@ -4,11 +4,11 @@ use std::path::Path;
 
 #[derive(Debug, clap::Parser)]
 pub struct ArchiveCommand {
-    #[clap(short, help = "the car file for archive.")]
-    car: String,
-
     #[clap(short, help = "the source directory to be archived.")]
     source: String,
+
+    #[clap(short, help = "the car file for archive.")]
+    car: String,
 }
 
 impl ArchiveCommand {

--- a/bin/car-utils/src/archive.rs
+++ b/bin/car-utils/src/archive.rs
@@ -7,6 +7,9 @@ pub struct ArchiveCommand {
     #[clap(short, help = "the source directory to be archived.")]
     source: String,
 
+    #[clap(help = "wrap the file (applies to files only).", default_value = "false", long = "no-wrap")]
+    no_wrap_file: bool,
+
     #[clap(short, help = "the car file for archive.")]
     car: String,
 }
@@ -17,7 +20,7 @@ impl ArchiveCommand {
     /// `source` is the directory where the archive is prepared.
     pub(crate) fn execute(&self) -> Result<(), UtilError> {
         let file = std::fs::File::create(self.car.as_ref() as &Path).unwrap(); // todo handle error
-        archive_local(self.source.as_ref() as &Path, file)?;
+        archive_local(self.source.as_ref() as &Path, file, self.no_wrap_file)?;
         Ok(())
     }
 }

--- a/crates/blockless-car/Cargo.toml
+++ b/crates/blockless-car/Cargo.toml
@@ -15,3 +15,7 @@ cid = "0.9"
 integer-encoding = "3.0.4"
 path-absolutize = "3"
 quick-protobuf = { default-features = false, features = ["std"], version = "0.8" }
+
+[dev-dependencies]
+tempdir = "0.3.7"
+

--- a/crates/blockless-car/examples/archive.rs
+++ b/crates/blockless-car/examples/archive.rs
@@ -8,5 +8,5 @@ fn main() {
         .nth(2)
         .expect("need the target file as argument");
     let file = std::fs::File::create(target).unwrap();
-    archive_local(file_name, file).unwrap();
+    archive_local(file_name, file, true).unwrap();
 }

--- a/crates/blockless-car/src/error.rs
+++ b/crates/blockless-car/src/error.rs
@@ -19,4 +19,7 @@ pub enum CarError {
 
     #[error("Not found {0}")]
     NotFound(String),
+
+    #[error("Invalid not implemented: {0}")]
+    NotImplemented(String),
 }

--- a/crates/blockless-car/src/utils/archive_local.rs
+++ b/crates/blockless-car/src/utils/archive_local.rs
@@ -227,7 +227,7 @@ pub fn raw_cid(data: &[u8]) -> Cid {
 
 /// walk all directory, and record the directory informations.
 /// `WalkPath` contain the index in children.
-pub fn walk_dir(root: impl AsRef<Path>) -> Result<(Vec<WalkPath>, WalkPathCache), CarError> {
+pub fn walk_path(root: impl AsRef<Path>) -> Result<(Vec<WalkPath>, WalkPathCache), CarError> {
     let root_path: Rc<PathBuf> = Rc::new(root.as_ref().absolutize()?.into());
 
     let mut queue = VecDeque::from(vec![root_path.clone()]);

--- a/crates/blockless-car/src/utils/archive_local.rs
+++ b/crates/blockless-car/src/utils/archive_local.rs
@@ -100,7 +100,7 @@ where
     
     let (walk_paths, mut path_cache) = walk_dir(path)?;
     for walk_path in &walk_paths {
-        process_path(root_path.clone(), &mut root_cid, walk_path, &mut path_cache, &mut writer)?;
+        process_path(root_path.clone(), &mut root_cid, &mut writer, walk_path, &mut path_cache)?;
     }
     let root_cid = root_cid.ok_or(CarError::NotFound("root cid not found.".to_string()))?;
     let header = CarHeader::V1(CarHeaderV1::new(vec![root_cid]));
@@ -110,9 +110,9 @@ where
 fn process_path<W: std::io::Write + std::io::Seek>(
     root_path: impl AsRef<Path>,
     root_cid: &mut Option<Cid>,
+    writer: &mut CarWriterV1<W>,
     (abs_path, parent_idx): &(Rc<PathBuf>, Option<usize>),
     path_cache: &mut WalkPathCache,
-    writer: &mut CarWriterV1<W>,
 ) -> Result<(), CarError> {
     let unixfs = path_cache.get_mut(abs_path).unwrap();
     for link in unixfs.links.iter_mut() {

--- a/crates/blockless-car/src/utils/archive_local.rs
+++ b/crates/blockless-car/src/utils/archive_local.rs
@@ -64,7 +64,7 @@ impl<'a> Read for LimitedFile<'a> {
 
 fn cid_gen() -> impl FnMut(WriteStream) -> Option<Result<Cid, CarError>> {
     let mut hash_codec = Blake2b256::default();
-    return move |w: WriteStream| match w {
+    move |w: WriteStream| match w {
         WriteStream::Bytes(bs) => {
             hash_codec.update(bs);
             None
@@ -77,7 +77,7 @@ fn cid_gen() -> impl FnMut(WriteStream) -> Option<Result<Cid, CarError>> {
             };
             Some(Ok(Cid::new_v1(RawCodec.into(), h)))
         }
-    };
+    }
 }
 
 /// archive the directory to the target CAR format file


### PR DESCRIPTION
## Add support for single file archiving
- The parent directory is simply referred to when archiving single file
- Added preliminary support for `--no-wrap` flag - with default value set to `false` (wrap single files into dir)
  - This is the same behaviour as `ipfs-car pack`

Archiving single files is required to support `--no-wrap` option (in a future/next PR).
- This PR enables us to address: https://github.com/blocklessnetwork/blockless-car/issues/59

Updated output for `car utils ar --help`
```
Archive local file system to a car file

Usage: car-utils ar [OPTIONS] -s <SOURCE> -c <CAR>

Options:
  -s <SOURCE>      the source directory to be archived.
      --no-wrap    wrap the file (applies to files only).
  -c <CAR>         the car file for archive.
  -h, --help       Print help
```

Additional changes:
- Refactored the archival code for readability
- Added unit tests for archiving dir and file
